### PR TITLE
Lighterweight dependencies

### DIFF
--- a/about/features/index.md
+++ b/about/features/index.md
@@ -12,3 +12,4 @@ sidebar:
 - Generates report and metrics of violations and actions.
 - Provides an API for integration.
 - Highly configurable for different needs.
+- Supports 2 tech stacks:  run with Kafka, Zookeeper, Memcached and Cassandra, or run with lighter weight dependencies of just Redis and Cassandra.

--- a/about/index.md
+++ b/about/index.md
@@ -25,7 +25,7 @@ If you have large size Kuberentes clusters with a lot of tenants. and you need s
 
 ### What Kind of Entities Does It Monitor?
 
-Any entities which deployed to your Kubernetes cluster such as Deployments, Pods, Jobs/CronJobs, Ingresses and namespaces.
+Any entities which deployed to your Kubernetes cluster such as Deployments, DaemonSets, Pods, Jobs/CronJobs, Ingresses, Namespaces and ResourceQuotas.
 
 ### What Kind of Actions Does It Take?
 

--- a/about/violations/index.md
+++ b/about/violations/index.md
@@ -9,7 +9,7 @@ sidebar:
 
 **Violation**|**Why**|**Example**
 -----|-----|-----
-Image Size |Efficiency |5 GB image size
+Image Size | Efficiency | 5 GB image size
 Image Repo | Security | Downloading image from a shady repo
 Extra Capabilities | Security | Setting UID/GUID
 Privileged Mode | Security| Root containers
@@ -17,3 +17,7 @@ Single Replica | Availability | Not 12-factor app
 Invalid Ingress | Security/Stability |  Having \"*" in ingress
 Mount Host Vols | Security/Stability | Mounting kubernetes system files
 No Owner  | Security | No owner annotation for namespace
+Required Entity | Security/Stability | Required pod not deployed
+Required Annotation  | Security/Stability | Required annotation for reporting not configured
+Required Labels  | Security/Stability | Required label for reporting not configured
+

--- a/deploy/config/index.md
+++ b/deploy/config/index.md
@@ -11,3 +11,14 @@ K8Guard comes with tons of configurations, currently the documentation for it is
 
 * [.env-template](https://github.com/k8guard/k8guard-start-from-here/blob/master/.env-template)
 * [.env-creds-template](https://github.com/k8guard/k8guard-start-from-here/blob/master/.env-creds-template)
+
+
+Some of the configuration values (as noted in the `.env-template` file) have a rule format that can used to filter on namespaces, entity types, entity names, and values, in addition to excluding.  Examples:
+
+Configuration setting | Configuration value | Description
+-----|-----|-----
+`K8GUARD_IGNORED_VIOLATIONS` | `mynamespace:*:*:PRIVILEGED` | will ignore any PRIVILEGED violations for all types within `mynamespace`.
+`K8GUARD_IGNORED_VIOLATIONS` | `!mynamespace:daemonset:*:PRIVILEGED` | will ignore any PRIVILEGED violations for all daemonsets in any namespace but `mynamespace`.
+`K8GUARD_IGNORED_VIOLATIONS` | `*:daemonset:kube2iam:PRIVILEGED` | will ignore any PRIVILEGED violations only for daemonsets named `kube2iam` across all namespaces.
+`K8GUARD_REQUIRED_LABELS` | `!kube-system:pod:*:productcode` | ensures that all pods in all namespaces except `kube-system` have the label `productcode`.
+`K8GUARD_REQUIRED_ENTITIES` | `!kube-system:resourcequota:myquota:*` | ensures that all namespaces except `kube-system` have a resourcequota named `myquota`. 

--- a/deploy/docker-compose/index.md
+++ b/deploy/docker-compose/index.md
@@ -7,7 +7,7 @@ sidebar:
 
 
 
-##  Deploy Option 1: Run in docker-compose
+##  Deploy Option 1: Run in docker-compose using Kafka, Zookeeper, Memcached and Cassandra
 
 1. Config:
 	edit `.env` and `env-creds` files. (default values should work fine)
@@ -21,24 +21,24 @@ sidebar:
 1. Bring up the core services (cassandra, kafka, memcached):
 
 	```
-	make up-core
+	make up-core-compose
 	```
 1.  Bring up action, in a new terminal run:
 
 	```
-	make up-action
+	make up-action-compose
 	```
 
 1.  Bring up discover, in a new terminal run:
 
 	```
-	make up-discover
+	make up-discover-compose
 	```
 
 1.  To bring up report, in a new terminal run:
 
 	```
-	make up-report
+	make up-report-compose
 	```
 
 1. Open the discover service url in the browser:
@@ -56,15 +56,78 @@ sidebar:
 - To clean the docker-compose
 
 	```
-	make clean
+	make clean-compose
 	```
 
 - Hint alternatively, you can clean individual services:
 
-	`make clean-action`
+	`make clean-action-compose`
 
-	`make clean-discover`
+	`make clean-discover-compose`
 
-	`make clean-report`
+	`make clean-report-compose`
 
-	`make clean-core`
+	`make clean-core-compose`
+
+
+##  Deploy Option 2: Alternatively, run in docker-compose with lighter weight dependencies of Redis and Cassandra
+
+1. Config:
+	edit `.env` and `env-creds` files. (default values should work fine)
+
+1. Set your kubernetes context to the cluster you want k8guard to run against.
+
+	```
+	kubectl config use-context REPLACE_WITH_YOUR_CONTEXT
+	```
+
+1. Bring up the core services (cassandra, kafka, memcached):
+
+	```
+	make up-core-compose-lightweight
+	```
+1.  Bring up action, in a new terminal run:
+
+	```
+	make up-action-compose-lightweight
+	```
+
+1.  Bring up discover, in a new terminal run:
+
+	```
+	make up-discover-compose-lightweight
+	```
+
+1.  To bring up report, in a new terminal run:
+
+	```
+	make up-report-compose-lightweight
+	```
+
+1. Open the discover service url in the browser:
+    ```
+    http://localhost:3000
+    ```
+
+1. Open the report service url in the browser:
+    ```
+    http://localhost:3001
+    ```
+
+### Clean up docker-compose
+
+- To clean the docker-compose
+
+	```
+	make clean-compose-lightweight
+	```
+
+- Hint alternatively, you can clean individual services:
+
+	`make clean-action-compose-lightweight`
+
+	`make clean-discover-compose-lightweight`
+
+	`make clean-report-compose-lightweight`
+
+	`make clean-core-compose-lightweight`

--- a/deploy/minikube/index.md
+++ b/deploy/minikube/index.md
@@ -6,9 +6,10 @@ sidebar:
 ---
 
 
+
 In this option you will test k8guard against a minikube context and will also deploy it to minikube. (safest way for development)
 
-### Setup and Start Minikube
+## Setup and Start Minikube
 1. Install [Minikube](https://github.com/kubernetes/minikube/releases/tag/v0.20.0)
 
 1. Start Minikube (with kubernetes v1.6.4)
@@ -19,7 +20,9 @@ minikube start --memory 4096 --kubernetes-version v1.6.4
 * To try k8guard with an older version Kubernetes please refer to [version compatibility matrix](http://0.0.0.0:4000/deploy/versions/).
 
 
-### Build & Deploy to Minikube
+## Build & Deploy to Minikube
+
+###  Deploy Option 1: Run in minikube using Kafka, Zookeeper, Memcached and Cassandra
 
 Do the following two commands in the same terminal:
 
@@ -33,8 +36,22 @@ eval $(minikube docker-env)
  make build-deploy-minikube
  ```
 
+###  Deploy Option 2: Run in minikube with lighter weight dependencies of Redis and Cassandra
 
-### Try It in Browser:
+Do the following two commands in the same terminal:
+
+1. Use minikube docker
+```
+eval $(minikube docker-env)
+```
+
+2. Build and deploy
+ ```
+ make build-deploy-minikube-lightweight
+ ```
+
+
+## Try It in Browser:
 
 Give it a couple minutes, then hit the service urls:
 


### PR DESCRIPTION
Added support for an alternate lighter weight deployment of just Redis and Cassandra instead of Kafka, Zookeeper, Memcached and Cassandra.
